### PR TITLE
Update drv_hwtimer.c

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-12-10     zylx         first version
  * 2020-06-16     thread-liu   Porting for stm32mp1
+ * 2020-08-25     linyongkang  Fix the timer clock frequency doubling problem
  */
 
 #include <board.h>
@@ -164,6 +165,12 @@ static void timer_init(struct rt_hwtimer_device *timer, rt_uint32_t state)
         tim = (TIM_HandleTypeDef *)timer->parent.user_data;
         tim_device = (struct stm32_hwtimer *)timer;
 
+        uint32_t FLatency = 0;
+        RCC_ClkInitTypeDef RCC_ClkInitStruct;
+        HAL_RCC_GetClockConfig(&RCC_ClkInitStruct, &FLatency);
+        uint32_t pclk1_doubler = 1 + ( RCC_ClkInitStruct.APB1CLKDivider != RCC_HCLK_DIV1 );
+        uint32_t pclk2_doubler = 1 + ( RCC_ClkInitStruct.APB2CLKDivider != RCC_HCLK_DIV1 );
+
         /* time init */
 #if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
         if (tim->Instance == TIM9 || tim->Instance == TIM10 || tim->Instance == TIM11)
@@ -176,12 +183,12 @@ static void timer_init(struct rt_hwtimer_device *timer, rt_uint32_t state)
 #endif
         {
 #if !defined(SOC_SERIES_STM32F0) && !defined(SOC_SERIES_STM32G0)
-            prescaler_value = (uint32_t)(HAL_RCC_GetPCLK2Freq() * 2 / 10000) - 1;
+            prescaler_value = (uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk2_doubler / 10000) - 1;
 #endif
         }
         else
         {
-            prescaler_value = (uint32_t)(HAL_RCC_GetPCLK1Freq() * 2 / 10000) - 1;
+            prescaler_value = (uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk1_doubler / 10000) - 1;
         }
         tim->Init.Period            = 10000 - 1;
         tim->Init.Prescaler         = prescaler_value;
@@ -290,6 +297,12 @@ static rt_err_t timer_ctrl(rt_hwtimer_t *timer, rt_uint32_t cmd, void *arg)
         /* set timer frequence */
         freq = *((rt_uint32_t *)arg);
 
+        uint32_t FLatency = 0;
+        RCC_ClkInitTypeDef RCC_ClkInitStruct;
+        HAL_RCC_GetClockConfig(&RCC_ClkInitStruct, &FLatency);
+        uint32_t pclk1_doubler = 1 + ( RCC_ClkInitStruct.APB1CLKDivider != RCC_HCLK_DIV1 );
+        uint32_t pclk2_doubler = 1 + ( RCC_ClkInitStruct.APB2CLKDivider != RCC_HCLK_DIV1 );
+
 #if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
         if (tim->Instance == TIM9 || tim->Instance == TIM10 || tim->Instance == TIM11)
 #elif defined(SOC_SERIES_STM32L4)
@@ -300,19 +313,13 @@ static rt_err_t timer_ctrl(rt_hwtimer_t *timer, rt_uint32_t cmd, void *arg)
         if (0)
 #endif
         {
-#if defined(SOC_SERIES_STM32L4)
-            val = HAL_RCC_GetPCLK2Freq() / freq;
-#elif defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1)
-            val = HAL_RCC_GetPCLK2Freq() * 2 / freq;
+#if !defined(SOC_SERIES_STM32F0) && !defined(SOC_SERIES_STM32G0)
+            val = (uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk2_doubler / 10000) - 1;
 #endif
         }
         else
         {
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1)
-            val = HAL_RCC_GetPCLK1Freq() * 2 / freq;
-#elif defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0)
-            val = HAL_RCC_GetPCLK1Freq() / freq;
-#endif
+            val = HAL_RCC_GetPCLK1Freq() * pclk1_doubler / freq;
         }
         __HAL_TIM_SET_PRESCALER(tim, val - 1);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
       修复STM32硬件定时器配置时候可能存在的逻辑问题。例如当 APB1CLKDivider 或 APB2CLKDivider为RCC_HCLK_DIV1的时候，此时旧版本的 drv_hwtimer.c 中仍然会以 PCLKx 频率的2倍计算. 由此造成设置的定时时间变成了原来的2倍。例如定时1S，实际得到的结果是2S。
       由“STM32的硬件定时器在 APBxCLKDivider 为 RCC_HCLK_DIV1 的时候，timer clocks 频率等于外设总线时钟PCLKx， 反之 timer clocks 为 PCLKx 的2倍”规则。在进行定时器计算的时候均先获取当前 APBxCLKDivider 的配置情况，然后再决定是否需要对PCLx的时钟进行倍频计算。

当前已经测试板卡/MCU:STM32F412xx实际运行测试。其他STM32F0xx、STM32F1xx、STM32F2xx、STM32F3xx、STM32F7xx、STM32H7xx、STM32MP15x系列均使用STM32CubeMX进行验证，时钟逻辑均是如此。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
